### PR TITLE
Update menu template part selection

### DIFF
--- a/pulsar-blocks.php
+++ b/pulsar-blocks.php
@@ -4,7 +4,7 @@
  * Description:       A collection of blocks we use at eighteen73.
  * Requires at least: 6.3
  * Requires PHP:      7.4
- * Version:           0.17.3
+ * Version:           0.17.4
  * Author:            eighteen73
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This pull request refactors the handling of template parts in the `Menu` class to use block-based APIs and improves the clarity of template part metadata. The changes streamline the codebase by replacing older query methods with more modern and efficient alternatives.

### Refactoring Template Part Handling:
* [`includes/classes/Menu.php`](diffhunk://#diff-6a43778870fcc87616a76fe4b26e68435d7ff00a01186460cc9336270510b52dL167-R171): Replaced `get_posts` with `get_block_templates` for fetching template parts, simplifying the query logic and aligning with block-based APIs.
* [`includes/classes/Menu.php`](diffhunk://#diff-6a43778870fcc87616a76fe4b26e68435d7ff00a01186460cc9336270510b52dL434-R435): Updated the `render_template_part` method to use `get_block_template` instead of custom query logic, improving performance and readability.

### Metadata and Label Updates:
* [`includes/classes/Menu.php`](diffhunk://#diff-6a43778870fcc87616a76fe4b26e68435d7ff00a01186460cc9336270510b52dL260-R249): Renamed the template part area from `menu_item` to `submenu` and updated associated descriptions and labels for better clarity.

### UI Improvements:
* [`includes/classes/Menu.php`](diffhunk://#diff-6a43778870fcc87616a76fe4b26e68435d7ff00a01186460cc9336270510b52dL199-R184): Changed the dropdown values and labels for template parts to use `id` and `title` instead of `post_name` and `post_title`, ensuring consistency with block template APIs.