### PR TITLE
Cache menu items

### DIFF
--- a/src/menu/render.php
+++ b/src/menu/render.php
@@ -26,7 +26,11 @@ if ( empty( $location ) ) {
 	return;
 }
 
-$all_items = Menu::get_formatted_items_for_location( $location );
+$menu_transient = "pulsar_blocks_menu_{$location}";
+if ( false === ( $all_items = get_transient( $menu_transient ) ) ) {
+	$all_items = Menu::get_formatted_items_for_location( $location );
+	set_transient( $menu_transient, $all_items, 60 );
+}
 
 if ( ! is_array( $all_items ) || empty( $all_items ) ) {
 	return;


### PR DESCRIPTION
There is be a measurable saving to requests by caching the menu items.

In this initial commit I've sharing my test using a transient but I'm starting the PR as a draft in case you have a different and better idea for this.

Ideally the transient storage would be cleared when a menu is updated rather than giving it a short TTL. Is that possible?