### PR TITLE
Rework caching to only cache menu items not html

### DIFF
--- a/includes/classes/Menu.php
+++ b/includes/classes/Menu.php
@@ -375,16 +375,19 @@ class Menu {
 		$cached_items  = get_transient( $transient_key );
 
 		if ( false !== $cached_items ) {
-			return $cached_items;
-		}
+			$menu_items = $cached_items;
+		} else {
+			// No cache found, generate fresh data
+			$locations = get_nav_menu_locations();
+			if ( ! isset( $locations[ $location_slug ] ) || empty( $locations[ $location_slug ] ) ) {
+				return null;
+			}
+			$menu_id    = $locations[ $location_slug ];
+			$menu_items = wp_get_nav_menu_items( $menu_id );
 
-		// No cache found, generate fresh data
-		$locations = get_nav_menu_locations();
-		if ( ! isset( $locations[ $location_slug ] ) || empty( $locations[ $location_slug ] ) ) {
-			return null;
+			// Cache the result for 1 month
+			set_transient( $transient_key, $menu_items, MONTH_IN_SECONDS );
 		}
-		$menu_id    = $locations[ $location_slug ];
-		$menu_items = wp_get_nav_menu_items( $menu_id );
 
 		if ( false === $menu_items || empty( $menu_items ) ) {
 			return [];
@@ -432,9 +435,6 @@ class Menu {
 
 		// Process ancestor/parent relationships after all items are formatted
 		self::add_ancestor_classes( $formatted_items );
-
-		// Cache the result for 1 month
-		set_transient( $transient_key, $formatted_items, MONTH_IN_SECONDS );
 
 		return $formatted_items;
 	}


### PR DESCRIPTION
Issue with caching html is that it caches the "current-menu-item" class which needs to remain dynamic 

I've reworked the cache so that it only caches the menu items rather than the markup itself

done some testing with query monitor profiling to see the impact below is an average range i was seeing for the time of the get_formatted_items_for_location function (i think the time is seconds):

No caching: 0.008 - 0.0120

Caching menu html: 0.0002 - 0.0003

Caching menu items: 0.0009 - 0.0014

So caching just the items does effect the time but not by a great amount and it is still much faster than not caching it