### PR TITLE
Fix: convert lightgallery import to "use" syntax

### DIFF
--- a/src/media-viewer/style.scss
+++ b/src/media-viewer/style.scss
@@ -1,3 +1,10 @@
+@use "~lightgallery/scss/lg-variables" as * with (
+	$lg-path-fonts: "../../assets/fonts",
+	$lg-path-images: "../../assets/img"
+);
+@use "~lightgallery/scss/lg-mixins" as *;
+@use "~lightgallery/scss/lightgallery-core" as *;
+
 $grid-areas: (
 	1: "one",
 	2: "two",
@@ -8,13 +15,6 @@ $grid-areas: (
 	7: "seven",
 	8: "eight"
 );
-
-@use "~lightgallery/scss/lg-variables" as * with (
-	$lg-path-fonts: "../../assets/fonts",
-	$lg-path-images: "../../assets/img"
-);
-@use "~lightgallery/scss/lg-mixins" as *;
-@use "~lightgallery/scss/lightgallery-core" as *;
 
 .wp-block-pulsar-media-viewer {
 	position: relative;

--- a/src/media-viewer/style.scss
+++ b/src/media-viewer/style.scss
@@ -1,7 +1,3 @@
-// Fix path issues with assets
-$lg-path-fonts: "../../assets/fonts";
-$lg-path-images: "../../assets/img";
-
 $grid-areas: (
 	1: "one",
 	2: "two",
@@ -13,7 +9,12 @@ $grid-areas: (
 	8: "eight"
 );
 
-@import "~lightgallery/scss/lightgallery-core";
+@use "~lightgallery/scss/lg-variables" as * with (
+	$lg-path-fonts: "../../assets/fonts",
+	$lg-path-images: "../../assets/img"
+);
+@use "~lightgallery/scss/lg-mixins" as *;
+@use "~lightgallery/scss/lightgallery-core" as *;
 
 .wp-block-pulsar-media-viewer {
 	position: relative;


### PR DESCRIPTION
Converted the import to the new "use" syntax to fix build

Required variables directly referenced so the variable overrides could still work

Required mixins directly referenced as it wasn't finding them otherwise