### PR TITLE
Hotfix/svg attributes

### DIFF
--- a/pulsar-blocks.php
+++ b/pulsar-blocks.php
@@ -4,7 +4,7 @@
  * Description:       A collection of blocks we use at eighteen73.
  * Requires at least: 6.3
  * Requires PHP:      7.4
- * Version:           1.6.0
+ * Version:           1.6.1
  * Author:            eighteen73
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/icon-text/render.php
+++ b/src/icon-text/render.php
@@ -86,7 +86,7 @@ $tag = $has_link ? 'a' : 'div';
 								'd'    => true,
 								'fill' => true,
 								'fill-rule' => true,
-                                'clip-rule' => true,
+								'clip-rule' => true,
 							],
 						];
 

--- a/src/icon-text/render.php
+++ b/src/icon-text/render.php
@@ -70,23 +70,28 @@ $tag = $has_link ? 'a' : 'div';
 
 						// Define allowed SVG tags and attributes for security
 						$allowed_svg_tags = [
-							'svg'   => [
-								'class'           => true,
-								'aria-hidden'     => true,
-								'aria-labelledby' => true,
-								'role'            => true,
-								'xmlns'           => true,
-								'width'           => true,
-								'height'          => true,
-								'viewbox'         => true,
+							'svg'     => [
+								'class'       => true,
+								'xmlns'       => true,
+								'width'       => true,
+								'height'      => true,
+								'viewbox'     => true,
+								'aria-hidden' => true,
+								'role'        => true,
+								'focusable'   => true,
 							],
-							'g'     => [ 'fill' => true ],
-							'title' => [ 'title' => true ],
-							'path'  => [
-								'd'    => true,
-								'fill' => true,
+							'path'    => [
+								'fill'      => true,
 								'fill-rule' => true,
-								'clip-rule' => true,
+								'd'         => true,
+								'transform' => true,
+							],
+							'polygon' => [
+								'fill'      => true,
+								'fill-rule' => true,
+								'points'    => true,
+								'transform' => true,
+								'focusable' => true,
 							],
 						];
 

--- a/src/icon-text/render.php
+++ b/src/icon-text/render.php
@@ -85,6 +85,8 @@ $tag = $has_link ? 'a' : 'div';
 							'path'  => [
 								'd'    => true,
 								'fill' => true,
+								'fill-rule' => true,
+                                'clip-rule' => true,
 							],
 						];
 


### PR DESCRIPTION
Found an issue where sometimes the svgs get filled like this 
<img width="63" height="60" alt="CleanShot 2026-02-11 at 10 49 50" src="https://github.com/user-attachments/assets/9bd0a213-c26b-4592-b650-4d5053d4a22d" />

Found it was due to some attributes getting stripped out which control how the fill is added

## Testing
Upload an svg that uses `fill-rule` or `clip-rule` (these are normally more complicated svgs), prior to update it will fill the whole svg, after the update it will only fill the paths correctly