### PR TITLE
Fix: remove block appender from scope of carousel

### DIFF
--- a/pulsar-blocks.php
+++ b/pulsar-blocks.php
@@ -4,7 +4,7 @@
  * Description:       A collection of blocks we use at eighteen73.
  * Requires at least: 6.3
  * Requires PHP:      7.4
- * Version:           1.6.1
+ * Version:           1.6.2
  * Author:            eighteen73
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/embla-carousel/edit.js
+++ b/src/embla-carousel/edit.js
@@ -72,6 +72,7 @@ export default function Edit({
 	const [emblaRef, emblaApi] = useEmblaCarousel({
 		...options,
 		container: getContainer(),
+		slides: ':scope > :not(.block-list-appender)',
 	});
 
 	useEffect(() => {


### PR DESCRIPTION
Noticed when loop is set to true on the embla carousel the positioning of items was incorrect

Cause:
Found that the `block-list-appender` element was being included as if it was a slide and was being included in positioning calculations

Fix:
useEmblaCarousel has a "slides" prop that can be used to ignore that element

Testing:
Create a carousel with enough items to go off the screen in the editor, ensure "loop" is enabled, without the fix the positioning will be wrong so you wont see the items positioned next to the first item in the carousel. With the fix the items will be positioned there, and it will also be draggable now
