### PR TITLE
Fix: remove aspect ratio from carousel when not empty

### DIFF
--- a/pulsar-blocks.php
+++ b/pulsar-blocks.php
@@ -4,7 +4,7 @@
  * Description:       A collection of blocks we use at eighteen73.
  * Requires at least: 6.3
  * Requires PHP:      7.4
- * Version:           1.6.2
+ * Version:           1.6.3
  * Author:            eighteen73
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/embla-carousel-viewport/editor.scss
+++ b/src/embla-carousel-viewport/editor.scss
@@ -1,5 +1,4 @@
 .wp-block-pulsar-embla-carousel-viewport {
-	.embla__container:has(> .block-list-appender),
 	.embla__container:empty {
 		aspect-ratio: 16 / 9;
 	}


### PR DESCRIPTION
Aspect ratio was being applied when the block appender was visible but isn't necessary when the block has children as they set their own height